### PR TITLE
Reduce require context in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,12 @@ try {
 
 const runtime = process.versions['electron'] ? 'electron' : 'node';
 const essential = runtime + '-v' + process.versions.modules + '-' + process.platform + '-' + process.arch;
-const modulePath = path.join(__dirname, 'builds', essential, 'build', 'Release', 'iohook.node');
+const runtime = process.versions['electron'] ? 'electron' : 'node';
+const essential = runtime + '-v' + process.versions.modules + '-' + process.platform + '-' + process.arch;
 if (process.env.DEBUG) {
-  console.info('Loading native binary:', modulePath);
+  console.info('Loading native binary: ./builds/' + essential + '/build/Release/iohook.node');
 }
-let NodeHookAddon = require(modulePath);
+let NodeHookAddon = require('./builds/' + essential + '/build/Release/iohook.node');
 
 const events = {
   3: 'keypress',


### PR DESCRIPTION
Using `'./builds/' + essential + '/build/Release/iohook.node'` instead of a unique variable `modulePath`, Webpack is able to import the `iohook.node` file (before the change, it would try to import every single file next to `index.js` (see https://stackoverflow.com/questions/25384360/how-to-prevent-moment-js-from-loading-locales-with-webpack/25426019#25426019)