### PR TITLE
Use x32 for ia32 arch (fixes #112)

### DIFF
--- a/install.js
+++ b/install.js
@@ -23,6 +23,7 @@ function onerror(err) {
  * @param cb Callback
  */
 function install(runtime, abi, platform, arch, cb) {
+  if (arch = "ia32") { arch = "x32"; }
   const essential = runtime + '-v' + abi + '-' + platform + '-' + arch;
   const pkgVersion = pkg.version;
   const currentPlatform = pkg.name + '-v' + pkgVersion + '-' + essential;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This is a simple fix to use x32 for the ia32 architecture.

## Motivation and Context
See #112

## How Has This Been Tested?
With the patch iohook installs locally on a 32-bit system.
It should be verified if this can break installation on other platforms.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
