### PR TITLE
Fix NPE when trying to call releaseCallback

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,7 +164,7 @@ class IOHook extends EventEmitter {
   /**
    * Specify that key event's `rawcode` property should be used instead of
    * `keycode` when listening for key presses.
-   * 
+   *
    * This allows iohook to be used in conjunction with other programs that may
    * only provide a keycode.
    * @param {Boolean} using
@@ -377,7 +377,9 @@ class IOHook extends EventEmitter {
 
         if (shortcutReleased) {
           // Call the released function handler
-          shortcut.releaseCallback(keysTmpArray);
+          if(shortcut.releaseCallback) {
+            shortcut.releaseCallback(keysTmpArray);
+          }
 
           // Remove this shortcut from our activate shortcuts array
           const index = this.activatedShortcuts.indexOf(shortcut);


### PR DESCRIPTION
Fix NPE when trying to call `releaseCallback`

Fix https://github.com/wilix-team/iohook/issues/131

## Description

Can now use `iohook.registerShortcut` without a 3rd `releaseCallback` argument (as [already documented](https://wilix-team.github.io/iohook/usage.html)). Previously it would crash after the shortcut triggered.

```js
const iohook = require('iohook');

iohook.start();

// m shortcut
iohook.registerShortcut([50], () => {
   console.log('shortcut triggered');
});
```


## How Has This Been Tested?

I was unable to run the test suite on Windows as `robotjs` was failing to install. And the tests appear to all fail on macOS (perhaps some accessibility security permission issue emulating the keyboard).


This file does exist, `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Tools\MSVC\14.15.26726\lib\x64\delayimp.lib`
```
...
LINK : fatal error LNK1181: cannot open input file 'DelayImp.lib' [C:\Users\MLM\Documents\GitHub\iohook\node_modules\robotjs\build\robotjs.vcxproj]
gyp ERR! build error
gyp ERR! stack Error: `C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe` failed with exit code: 1
gyp ERR! stack     at ChildProcess.onExit (C:\Users\MLM\AppData\Roaming\nvm\v10.12.0\node_modules\npm\node_modules\node-gyp\lib\build.js:262:23)
gyp ERR! stack     at ChildProcess.emit (events.js:182:13)
gyp ERR! stack     at Process.ChildProcess._handle.onexit (internal/child_process.js:240:12)
gyp ERR! System Windows_NT 10.0.17763
gyp ERR! command "C:\\Program Files\\nodejs\\node.exe" "C:\\Users\\MLM\\AppData\\Roaming\\nvm\\v10.12.0\\node_modules\\npm\\node_modules\\node-gyp\\bin\\node-gyp.js" "rebuild"
gyp ERR! cwd C:\Users\MLM\Documents\GitHub\iohook\node_modules\robotjs
gyp ERR! node -v v10.12.0
gyp ERR! node-gyp -v v3.8.0
gyp ERR! not ok
```


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] ~~My change requires a change to the documentation.~~
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
