### PR TITLE
Add libpng-dev as a dependency for Ubuntu

### DIFF
--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -18,7 +18,7 @@ Running `node examples/example.js` should show you a working result of your buil
 For build requirements for your OS look below.
 
 ## Ubuntu 16
-- `sudo apt install libx11-dev libxtst-dev libxt-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev`
+- `sudo apt install libx11-dev libxtst-dev libxt-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev libpng-dev`
 - `npm run build`
 
 ## macOS

--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -5,7 +5,7 @@ This is not required for regular users. You should follow this page only if you 
 :::
 
 Firstly, run this script
-```javascript
+```js
 const path = require('path');
 const runtime = process.versions['electron'] ? 'electron' : 'node';
 const essential = runtime + '-v' + process.versions.modules + '-' + process.platform + '-' + process.arch;

--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -5,7 +5,7 @@ This is not required for regular users. You should follow this page only if you 
 :::
 
 Firstly, run this script
-```js
+```javascript
 const path = require('path');
 const runtime = process.versions['electron'] ? 'electron' : 'node';
 const essential = runtime + '-v' + process.versions.modules + '-' + process.platform + '-' + process.arch;


### PR DESCRIPTION
While likely available in Ubuntu already, `libpng-dev` is not included in Debian, and most Debian users use Ubuntu instructions.

The same package is available under Ubuntu, so it makes sense to include it here, especially if the Ubuntu user previously uninstalled it for whatever reason.