### PR TITLE
Moved @types/node to devDependencies and updated version in package-lock

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
   - npm -g i npm@latest
-  - npm i --ignore-scripts
+  - npm i -D --ignore-scripts
   - for /f %%i in ('node -v') do set exact_nodejs_version=%%i
   - npm run build
   # - npm run test || travis_terminate 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,9 @@ install:
   - set PATH=C:\Program Files (x86)\MSBuild\14.0\Bin;%PATH%
   - ps: Install-Product node $env:nodejs_version $env:platform
   - npm -g i npm@latest
-  - npm i -D --ignore-scripts
+  # TEMPORARY CHANGE: UNCOMMENT NEXT LINE AND REMOVE THE FOLLOWING ONE BEFORE MERGING
+  #- npm i -D --ignore-scripts
+  - npm i -D --ignore-scripts --expose-internals
   - for /f %%i in ('node -v') do set exact_nodejs_version=%%i
   - npm run build
   # - npm run test || travis_terminate 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iohook",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1229,7 +1229,8 @@
     "@types/node": {
       "version": "7.0.62",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-7.0.62.tgz",
-      "integrity": "sha512-sOCty/ewg1pBfNpK8bS5ALoPbJPEW6ualNMcd47LRtdgNabAdNKsbFojoexvk3MpMuu6PxxR6N1sRrPixFPhGA=="
+      "integrity": "sha512-sOCty/ewg1pBfNpK8bS5ALoPbJPEW6ualNMcd47LRtdgNabAdNKsbFojoexvk3MpMuu6PxxR6N1sRrPixFPhGA==",
+      "dev": true
     },
     "@vue/babel-preset-app": {
       "version": "3.0.0-beta.11",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   },
   "homepage": "https://github.com/wilix-team/iohook#readme",
   "dependencies": {
-    "@types/node": "^7.0.62",
     "bindings": "^1.3.0",
     "node-abi": "^2.4.0",
     "pump": "^1.0.3",
@@ -43,6 +42,7 @@
     "tar-fs": "^1.16.2"
   },
   "devDependencies": {
+    "@types/node": "^7.0.62",
     "archiver": "^2.1.1",
     "cmake-js": "^3.6.2",
     "jest": "^22.4.3",


### PR DESCRIPTION
Installing `@types/node` as a normal dependency really doesn't make much sense.