### PR TITLE
Update cmake-js with fork

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "archiver": "^2.1.1",
-    "cmake-js": "^5.1.0",
+    "cmake-js": "github:anoadragon453/cmake-js#anoa/delay_generator",
     "jest": "^22.4.3",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",


### PR DESCRIPTION
Building iohook for Electron v4 is going to require some updates to `cmake-js`, some of which haven't been merged yet. This PR change the branch to one that merged those PRs.

Note:: DO NOT MERGE THIS PR IN ITS CURRENT FORM.

If we're going with a fork we should have it be based off wilix-team's repo instead of mine.