### PR TITLE
Use VS C++ for Electron >= v4

### DIFF
--- a/build.js
+++ b/build.js
@@ -59,8 +59,8 @@ function build(runtime, version) {
       '--runtime=' + runtime
     ];
     console.log('Compiling iohook for ' + runtime + ' v' + version + '>>>>');
-    if (version.split('.')[0] > 4) {
-      process.env.msvs_toolset = 14
+    if (version.split('.')[0] >= 4) {
+      process.env.msvs_toolset = 15
       process.env.msvs_version = 2017
     } else {
       process.env.msvs_toolset = 12


### PR DESCRIPTION
We were using VS2017 for Electron v5 and above, instead of v4.