### PR TITLE
Add commandline options to build.js

### DIFF
--- a/build.js
+++ b/build.js
@@ -1,10 +1,15 @@
-const upload = require('prebuild/upload');
 const spawn = require('child_process').spawn;
 const fs = require('fs');
 const path = require('path');
 const mkdirp = require('mkdirp');
 const archiver = require('archiver');
 const zlib = require('zlib');
+const argv = require('minimist')(
+    process.argv.slice(2), {
+        // Specify that these arguments should be a string
+        "string": ["version", "runtime", "abi"]
+    }
+);
 const pkg = require('./package.json');
 
 function mode(octal) {
@@ -24,8 +29,18 @@ let cmakeJsPath = path.join(
   process.platform === 'win32' ? 'cmake-js.cmd' : 'cmake-js'
 );
 
-let targets = require('./package.json').supportedTargets;
 let files = [];
+let targets;
+
+// Check if a specific runtime has been specified from the command line
+if ("runtime" in argv && "version" in argv && "abi" in argv) {
+    targets = [[argv["runtime"],
+                argv["version"],
+                argv["abi"]]];
+} else {
+    // If not, use those defined in package.json
+    targets = require('./package.json').supportedTargets;
+}
 
 let chain = Promise.resolve();
 
@@ -47,6 +62,11 @@ targets.forEach(parts => {
 });
 
 chain = chain.then(function () {
+  if ("upload" in argv && argv["upload"] == false) {
+    // If no upload has been specified, don't attempt to upload
+    return;
+  }
+
   return uploadFiles(files)
 });
 
@@ -107,6 +127,7 @@ function tarGz(runtime, abi) {
 }
 
 function uploadFiles (files) {
+  const upload = require('prebuild/upload');
   return new Promise(function (resolve, reject) {
     console.log('Uploading ' + files.length + ' prebuilds(s) to Github releases');
     let opts = {

--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -29,6 +29,34 @@ For build requirements for your OS look below.
 - Install: msys2 with autotools, pkg-config, libtool, gcc, clang, glib, C++ Build Tools, cmake
 - `npm run build`
 
+## Building for specific versions of node
+
+After running `npm run build`, if you want to build iohook for a specific
+node/electron version, you can use `build.js` which features the following
+command line options:
+
+* `--runtime` specifies whether to build for Electron or plain node
+* `--version` specifies what version of Electron/node to build for
+* `--abi` specifies what [ABI version](https://nodejs.org/en/docs/guides/abi-stability/) of Electron/node to build against
+
+For example, to build for Electron v4.0.4, you would run:
+
+```
+node build.js --runtime electron --version 4.0.4 --abi 69
+```
+
+To see more examples of what values to use, view iohook's [package.json file](https://github.com/wilix-team/iohook/blob/master/package.json), under `supportedTargets`. The three values in each block are runtime, version and abi respectively.
+
+`--runtime`, `--version` and `--abi` must all be supplied to build for a specific node version. If they are not supplied, `build.js` will build for the versions specified under `supportedTargets` in your `package.json` (again, see iohook's [package.json file](https://github.com/wilix-team/iohook/blob/master/package.json) for details).
+
+* `--no-upload` tells the script not to attempt to upload the built files to GitHub afterwards
+
+Typically `build.js` is used as part of iohook's CI in order to upload newly-built binaries to NPM. This is thus the default behavior of the script. To prevent this, supply the `--no-upload` flag:
+
+```
+node build.js --no-upload
+```
+
 # Testing
 
 iohook uses Jest for automated testing. To execute tests, run `npm run test` in your console.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "iohook",
-  "version": "0.3.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2658,9 +2658,9 @@
       }
     },
     "big-integer": {
-      "version": "1.6.41",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
-      "integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w==",
+      "version": "1.6.43",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.43.tgz",
+      "integrity": "sha512-9dULc9jsKmXl0Aeunug8wbF+58n+hQoFjqClN7WeZwGLh0XJUWyJJ9Ee+Ep+Ql/J9fRsTVaeThp8MhiCCrY0Jg==",
       "dev": true
     },
     "big.js": {
@@ -2728,9 +2728,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha512-/qKPUQlaW1OyR51WeCPBvRnAlnZFUJkCSG5HzGnuIqhgyJtF+T94lFnn33eiazjRm2LAHVy2guNnaq48X9SJuw==",
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
       "dev": true
     },
     "bn.js": {
@@ -3471,9 +3471,8 @@
       "dev": true
     },
     "cmake-js": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-5.1.0.tgz",
-      "integrity": "sha512-bU7sgkRGkHEBdYopc0t+WawcJEMg6WEFuXt9c1rqAbLFSplndRE6y4XvlO/5pCgbqKtQM5zARQhBG+dUX/nWcw==",
+      "version": "github:crtxgg/cmake-js#4ad53126aa160de02d199710478f65c92a6addf0",
+      "from": "github:crtxgg/cmake-js#anoa/delay_generator",
       "dev": true,
       "requires": {
         "bluebird": "^3",
@@ -9588,9 +9587,10 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -9732,6 +9732,13 @@
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "requires": {
         "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
       }
     },
     "move-concurrently": {
@@ -10323,6 +10330,14 @@
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.10",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
+        }
       }
     },
     "optimize-css-assets-webpack-plugin": {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "archiver": "^2.1.1",
     "cmake-js": "github:crtxgg/cmake-js#anoa/delay_generator",
     "jest": "^22.4.3",
+    "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
     "nan": "^2.10.0",
     "prebuild": "^6.2.2",


### PR DESCRIPTION
So we wanted to be able to easily build a single version of `iohook.node` from source without having to build a version for every single node/electron version (default behavior) and also without attempting to upload the built files to GitHub afterwards (which causes an error for anything other than the CI).

So this PR adds a few options to `build.js`:

* `--no-upload` prevents attempting to upload builds to GitHub after they're completed
* `--version`, `--runtime` and `--abi` flags, which if all set will instead build a single specified version of iohook, and skip those specified in `package.json`.

As an example, to build for Electron v4.0.4 and prevent uploading afterwards, you would run:

```
node build.js --runtime electron --version 4.0.4 --abi 69 --no-upload
```

Requires the use of a new library, `minimist`, which does cmdline flag parsing. Initially tried doing this without a library but the code got quite messy.