### PR TITLE
use arg 'arch' for cmakejs

### DIFF
--- a/build.js
+++ b/build.js
@@ -75,8 +75,8 @@ function build(runtime, version) {
     let args = [
       'rebuild',
       '--runtime-version=' + version,
-      '--target_arch=' + arch,
-      '--runtime=' + runtime
+      '--runtime=' + runtime,
+      '--arch=' + arch
     ];
     console.log('Compiling iohook for ' + runtime + ' v' + version + '>>>>');
     if (version.split('.')[0] >= 4) {


### PR DESCRIPTION
Fixes #169 

Hi， @Djiit 

   i found the  problem by  using the tool 'signcheck'. The win32-ia32 release file are still 64 bit.

   you can try to rebuild ia32 iohook and use the tool 'signcheck' to see if it is 32bit . If there are no problems, can you republish  releases ?
