### PR TITLE
Add proxy and strict ssl options

### DIFF
--- a/install.js
+++ b/install.js
@@ -3,7 +3,8 @@
 const path = require('path');
 const fs = require('fs');
 const os = require('os');
-const get = require('simple-get');
+const nugget = require('nugget');
+const rc = require('rc');
 const pump = require('pump');
 const tfs = require('tar-fs');
 const zlib = require('zlib');
@@ -30,51 +31,62 @@ function install(runtime, abi, platform, arch, cb) {
   console.log('Downloading prebuild for platform:', currentPlatform);
   let downloadUrl = 'https://github.com/WilixLead/iohook/releases/download/v' + pkgVersion + '/' + currentPlatform + '.tar.gz';
 
-  let reqOpts = {url: downloadUrl};
-  let tempFile = path.join(os.tmpdir(), 'prebuild.tar.gz');
-  let req = get(reqOpts, function(err, res) {
-    if (err) {
-      return onerror(err);
-    }
-    if (res.statusCode !== 200) {
-      if (res.statusCode === 404) {
+  let nuggetOpts = {
+    dir: os.tmpdir(),
+    target: 'prebuild.tar.gz',
+    strictSSL: true
+  };
+
+  const npmrc = rc('npm', {});
+
+  if (npmrc && npmrc.proxy) {
+    nuggetOpts.proxy = npmrc.proxy;
+  }
+
+  if (npmrc && npmrc['https-proxy']) {
+    nuggetOpts.proxy = npmrc['https-proxy'];
+  }
+
+  if (npmrc && npmrc['strict-ssl'] === false) {
+    nuggetOpts.strictSSL = false;
+  }
+
+  nugget(downloadUrl, nuggetOpts, function(errors) {
+    if (errors) {
+      const error = errors[0];
+
+      if (error.message.indexOf('404') === -1) {
+        onerror(error);
+      } else {
         console.error('Prebuild for current platform (' + currentPlatform + ') not found!');
         console.error('Try to compile for your platform:');
         console.error('# cd node_modules/iohook;');
         console.error('# npm run compile');
         console.error('');
-        return onerror('Prebuild for current platform (' + currentPlatform + ') not found!');
+        onerror('Prebuild for current platform (' + currentPlatform + ') not found!');
       }
-      return onerror('Bad response from prebuild server. Code: ' + res.statusCode);
     }
-    pump(res, fs.createWriteStream(tempFile), function(err) {
-      if (err) {
-        throw err;
-      }
-      let options = {
-        readable: true,
-        writable: true,
-        hardlinkAsFilesFallback: true
-      };
-      let binaryName;
-      let updateName = function(entry) {
-        if (/\.node$/i.test(entry.name)) binaryName = entry.name
-      };
-      let targetFile = path.join(__dirname, 'builds', essential);
-      let extract = tfs.extract(targetFile, options)
-        .on('entry', updateName);
-      pump(fs.createReadStream(tempFile), zlib.createGunzip(), extract, function(err) {
-        if (err) {
-          return onerror(err);
-        }
-        cb()
-      })
-    })
-  });
 
-  req.setTimeout(30 * 1000, function() {
-    req.abort()
-  })
+    let options = {
+      readable: true,
+      writable: true,
+      hardlinkAsFilesFallback: true
+    };
+
+    let binaryName;
+    let updateName = function(entry) {
+      if (/\.node$/i.test(entry.name)) binaryName = entry.name
+    };
+    let targetFile = path.join(__dirname, 'builds', essential);
+    let extract = tfs.extract(targetFile, options)
+      .on('entry', updateName);
+    pump(fs.createReadStream(path.join(nuggetOpts.dir, nuggetOpts.target)), zlib.createGunzip(), extract, function(err) {
+      if (err) {
+        return onerror(err);
+      }
+      cb()
+    });
+  });
 }
 
 /**

--- a/install.js
+++ b/install.js
@@ -37,7 +37,13 @@ function install(runtime, abi, platform, arch, cb) {
     strictSSL: true
   };
 
-  const npmrc = rc('npm', {});
+  let npmrc = {};
+
+  try {
+    rc('npm', npmrc);
+  } catch (error) {
+    console.warn('Error reading npm configuration: ' + error.message);
+  }
 
   if (npmrc && npmrc.proxy) {
     nuggetOpts.proxy = npmrc.proxy;

--- a/package.json
+++ b/package.json
@@ -38,8 +38,9 @@
     "@types/node": "^7.0.62",
     "bindings": "^1.3.0",
     "node-abi": "^2.4.0",
+    "nugget": "^2.0.1",
     "pump": "^1.0.3",
-    "simple-get": "^2.8.1",
+    "rc": "^1.2.8",
     "tar-fs": "^1.16.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Pulls in proxy and strict-ssl settings from npm config file.

Replaces simple-get with nugget since the former does not support setting strict-ssl.