### PR TITLE
improve grab mouse click for x11

### DIFF
--- a/examples/mouse-click-propagation.js
+++ b/examples/mouse-click-propagation.js
@@ -1,0 +1,16 @@
+const iohook = require('../index.js');
+
+iohook.on("mouseup", (event) => console.log(event));
+
+let clickpropagation = true;
+
+iohook.on("keyup", (event) => {
+  if (event.keycode !== 57) return; // space key
+
+  clickpropagation ? iohook.disableClickPropagation(): iohook.enableClickPropagation();
+  clickpropagation = !clickpropagation;
+});
+
+iohook.start(true);
+
+console.log('Hook started. Use space key to enable or disable click propagation');


### PR DESCRIPTION
Hi guys,

## Description
I have made some refactor in my previous contribution #75  (enable/disable click propagation) for simplify the code and add a log when the grab mouse fails. Only for X11 users.  

Also add an example for test the feature with node.

## Motivation and Context
The code is more clear and logs a warning when the click propagation is not disabled, I have detected this behavior when the pointer is already grabbed by the system (for example when a context menu is open the pointer is not be able to be grabbed).

## How Has This Been Tested?
Tested with manual tests (you can use the example added if verification need).

## Screenshots (if appropriate):

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed. Question: are you sure the keyboard test works in linux ?
