### PR TITLE
fix(types): make start() param optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -6,9 +6,9 @@ import { EventEmitter } from 'events'
 declare class IOHook extends EventEmitter {
   /**
    * Start hooking engine. Call it when you ready to receive events
-   * @param {boolean} enableLogger If true, module will publish debug information to stdout
+   * @param {boolean} [enableLogger] If true, module will publish debug information to stdout
    */
-  start(enableLogger: boolean): void
+  start(enableLogger?: boolean): void
 
   /**
    * Stop rising keyboard/mouse events
@@ -61,7 +61,7 @@ declare class IOHook extends EventEmitter {
    * @param {Function} [releaseCallback] Callback for when shortcut released
    * @return {number} ShortcutId for unregister
    */
-  registerShortcut(keys: Array<string|number>, callback: Function, releaseCallback?: Function): number
+  registerShortcut(keys: Array<string | number>, callback: Function, releaseCallback?: Function): number
 
   /**
    * Unregister shortcut by ShortcutId
@@ -73,7 +73,7 @@ declare class IOHook extends EventEmitter {
    * Unregister shortcut via its key codes
    * @param {Array<string|number>} keys
    */
-  unregisterShortcut(keys: Array<string|number>): void
+  unregisterShortcut(keys: Array<string | number>): void
 
   /**
    * Unregister all shortcuts

--- a/index.js
+++ b/index.js
@@ -40,7 +40,7 @@ class IOHook extends EventEmitter {
 
   /**
    * Start hook process
-   * @param enableLogger Turn on debug logging
+   * @param {boolean} [enableLogger] Turn on debug logging
    */
   start(enableLogger) {
     if (!this.active) {
@@ -83,7 +83,7 @@ class IOHook extends EventEmitter {
    * @param shortcutId
    */
   unregisterShortcut(shortcutId) {
-    this.shortcuts.forEach((shortcut,i) => {
+    this.shortcuts.forEach((shortcut, i) => {
       if (shortcut.id === shortcutId) {
         this.shortcuts.splice(i, 1);
       }
@@ -377,7 +377,7 @@ class IOHook extends EventEmitter {
 
         if (shortcutReleased) {
           // Call the released function handler
-          if(shortcut.releaseCallback) {
+          if (shortcut.releaseCallback) {
             shortcut.releaseCallback(keysTmpArray);
           }
 


### PR DESCRIPTION
The `start()` param is optional in the docs.