### PR TITLE
fix: depreacated use of objc_msgSend

### DIFF
--- a/libuiohook/src/darwin/input_hook.c
+++ b/libuiohook/src/darwin/input_hook.c
@@ -598,8 +598,8 @@ static inline void process_system_key(uint64_t timestamp, CGEventRef event_ref) 
 	if( CGEventGetType(event_ref) == NX_SYSDEFINED) {
 		#ifdef USE_OBJC
 		// Contributed by Iván Munsuri Ibáñez <munsuri@gmail.com>
-		id event_data = objc_msgSend((id) objc_getClass("NSEvent"), sel_registerName("eventWithCGEvent:"), event_ref);
-		int subtype = (int) objc_msgSend(event_data, sel_registerName("subtype"));
+		id event_data = ((id(*)(id, SEL, void(*)))objc_msgSend)((id) objc_getClass("NSEvent"), sel_registerName("eventWithCGEvent:"), event_ref);
+		int subtype = (int) ((id(*)(id, SEL))objc_msgSend)(event_data, sel_registerName("subtype"));
 		#else
 		CFDataRef data = CGEventCreateData(kCFAllocatorDefault, event_ref);
 		//CFIndex len = CFDataGetLength(data);
@@ -609,7 +609,7 @@ static inline void process_system_key(uint64_t timestamp, CGEventRef event_ref) 
 		#endif
 		if (subtype == 8) {
 			#ifdef USE_OBJC
-			int data = (int) objc_msgSend(event_data, sel_registerName("data1"));
+			int data = (int) ((id(*)(id, SEL))objc_msgSend)(event_data, sel_registerName("data1"));
 			#endif
 
 			int key_code = (data & 0xFFFF0000) >> 16;
@@ -1239,7 +1239,7 @@ UIOHOOK_API int hook_run() {
 									// Create a garbage collector to handle Cocoa events correctly.
 									Class NSAutoreleasePool_class = (Class) objc_getClass("NSAutoreleasePool");
 									id pool = class_createInstance(NSAutoreleasePool_class, 0);
-									auto_release_pool = objc_msgSend(pool, sel_registerName("init"));
+									auto_release_pool = ((id(*)(id, SEL))objc_msgSend)(pool, sel_registerName("init"));
 									#endif
 
 									// Start the hook thread runloop.
@@ -1248,7 +1248,7 @@ UIOHOOK_API int hook_run() {
 
 									#ifdef USE_OBJC
 									//objc_msgSend(auto_release_pool, sel_registerName("drain"));
-									objc_msgSend(auto_release_pool, sel_registerName("release"));
+									((id(*)(id, SEL))objc_msgSend)(auto_release_pool, sel_registerName("release"));
 									#endif
 
 									// Lock back up until we are done processing the exit.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Change the way of calling function objc_msgSend().

## Motivation and Context
Unstrict usage of objc_sendMsg is deprecated since Xcode 6.
Of course, it is able to be fixed if the user builds the option 'Enable strict checking of objc_msgSend Calls' at the Xcode from yes to no.
However, this project is not an Xcode project, so there's no way to turn that option off.
So this pull request improves the way to call function objc_msgSend().

## How Has This Been Tested?
If you try to build it on the original source, you'll see that the compiler prints the error and stop compiling, saying "Too many arguments".
But if you try it with my source, you'll see that no error occurs, with 100% of compile.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ x ] All new and existing tests passed.
