### PR TITLE
add relative paths to rpath for mac build

### DIFF
--- a/build_def/darwin/binding.gyp
+++ b/build_def/darwin/binding.gyp
@@ -15,7 +15,8 @@
 		],
 		"link_settings": {
 				"libraries": [
-						"-Wl,-rpath,<!(node -e \"console.log('builds/' + process.env.gyp_iohook_runtime + '-v' + process.env.gyp_iohook_abi + '-' + process.env.gyp_iohook_platform + '-' + process.env.gyp_iohook_arch + '/build/Release')\")",
+						"-Wl,-rpath,@executable_path/.",
+						"-Wl,-rpath,@loader_path/.",
 						"-Wl,-rpath,<!(pwd)/build/Release/"
 				]
 		},

--- a/build_def/darwin/uiohook.gyp
+++ b/build_def/darwin/uiohook.gyp
@@ -25,7 +25,8 @@
 				"-framework Carbon",
 				"-framework ApplicationServices",
 				"-lobjc",
-				"-Wl,-rpath,<!(node -e \"console.log('builds/' + process.env.gyp_iohook_runtime + '-v' + process.env.gyp_iohook_abi + '-' + process.env.gyp_iohook_platform + '-' + process.env.gyp_iohook_arch + '/build/Release')\")",
+				"-Wl,-rpath,@executable_path/.",
+				"-Wl,-rpath,@loader_path/.",
 				"-Wl,-rpath,<!(pwd)/build/Release/"
 			]
 		},


### PR DESCRIPTION
For #268. This should fix where iohook.node looks for uiohook.dylib on the mac build. The gotcha is that the absolute compile path is hardcoded as an rpath during the build process at https://github.com/wilix-team/iohook/blob/39e90a8478b15dc332c959e6a31346449c6c63c9/build_def/darwin/binding.gyp#L19 which makes testing on the same machine on which it was built tricky. May want to just delete that line altogether but I left it in for now. I tested by temporarily renaming my build path and this worked for me.