### PR TITLE
Linux: Add `-lxkbcommon-x11 -lxkbcommon` lflags

### DIFF
--- a/build_def/linux/uiohook.gyp
+++ b/build_def/linux/uiohook.gyp
@@ -21,7 +21,9 @@
 						"-Wl,-rpath,<!(node -e \"console.log('builds/' + process.env.gyp_iohook_runtime + '-v' + process.env.gyp_iohook_abi + '-' + process.env.gyp_iohook_platform + '-' + process.env.gyp_iohook_arch + '/build/Release')\")",
 						"-Wl,-rpath,<!(pwd)/build/Release/",
 						"-lX11",
-						"-lX11-xcb"
+						"-lX11-xcb",
+						"-lxkbcommon-x11",
+						"-lxkbcommon"
 				]
 		},
 		"defines": [

--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -9,7 +9,7 @@ When you run `npm run build`, it will try to download a prebuilt for your platfo
 :::
 
 ## Linux
-- `sudo apt-get install -y libxkbcommon-x11-0 # Needed on WSL`
+- `sudo apt-get install -y libx11-dev libx11-xcb-dev libxkbcommon-dev libxkbcommon-x11-dev`
 - `npm run build`
 
 ## macOS


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add required lflags when building the library on Linux systems.

These flags were determined from `pkg-config --libs xkbcommon-x11` on my system.

## Motivation and Context
Following the discussions on #268, I was still encountering "`undefined symbol: xkb_x11_get_core_keyboard_device_id`" errors when using iohook on Linux. This seems to fix that bug on my system.

In #270 `-lX11-xcb` was added to the lflags, but `xkbcommon-x11` is also used by `libuiohook/src/x11/input_helper.c` and not covered by `-lX11-xcb`.

I've updated the Linux *manual build* documentation to say to install all of the required `dev` packages, which are needed even outside of WSL. I did not update `README.md` because I believe users looking there will be using the prebuilds, and not need the dev package. I didn't see any Linux CI steps to update -- let me know if I missed that.

## How Has This Been Tested?
I've only tested this locally on my machine. Let me know what other forms of testing would be appropriate here.

It's not sufficient, but here's the `ldd` output from before/after my change:

Before:

```
$ ldd build/Release/uiohook.so
	linux-vdso.so.1 =>  (0x00007ffc3efc9000)
	libX11.so.6 => /usr/lib/x86_64-linux-gnu/libX11.so.6 (0x00007f5d1fb94000)
	libX11-xcb.so.1 => /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1 (0x00007f5d1f992000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f5d1f775000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f5d1f3ab000)
	libxcb.so.1 => /usr/lib/x86_64-linux-gnu/libxcb.so.1 (0x00007f5d1f189000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f5d1ef85000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f5d200d7000)
	libXau.so.6 => /usr/lib/x86_64-linux-gnu/libXau.so.6 (0x00007f5d1ed81000)
	libXdmcp.so.6 => /usr/lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007f5d1eb7b000)
```

After, now with references to `libxkbcommon-x11.so` & `libxkbcommon.so`:

```
$ ldd build/Release/uiohook.so
	linux-vdso.so.1 =>  (0x00007ffc6fdd3000)
	libX11.so.6 => /usr/lib/x86_64-linux-gnu/libX11.so.6 (0x00007fa47cd5c000)
	libX11-xcb.so.1 => /usr/lib/x86_64-linux-gnu/libX11-xcb.so.1 (0x00007fa47cb5a000)
	libxkbcommon-x11.so.0 => /usr/lib/x86_64-linux-gnu/libxkbcommon-x11.so.0 (0x00007fa47c952000)
	libxkbcommon.so.0 => /usr/lib/x86_64-linux-gnu/libxkbcommon.so.0 (0x00007fa47c713000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fa47c4f6000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fa47c12c000)
	libxcb.so.1 => /usr/lib/x86_64-linux-gnu/libxcb.so.1 (0x00007fa47bf0a000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fa47bd06000)
	libxcb-xkb.so.1 => /usr/lib/x86_64-linux-gnu/libxcb-xkb.so.1 (0x00007fa47baeb000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fa47d29f000)
	libXau.so.6 => /usr/lib/x86_64-linux-gnu/libXau.so.6 (0x00007fa47b8e7000)
	libXdmcp.so.6 => /usr/lib/x86_64-linux-gnu/libXdmcp.so.6 (0x00007fa47b6e1000)
```

## Screenshots (if appropriate):
(none)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
