### PR TITLE
fixing linux prebuilds by linking xtst as well

### DIFF
--- a/build_def/linux/uiohook.gyp
+++ b/build_def/linux/uiohook.gyp
@@ -23,7 +23,8 @@
 						"-lX11",
 						"-lX11-xcb",
 						"-lxkbcommon-x11",
-						"-lxkbcommon"
+						"-lxkbcommon",
+						"-lXtst"
 				]
 		},
 		"defines": [


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
#279 linked xkbcommon-x11 and X11-xcb, but that wasn't all that was missing for Linux builds. The error after that PR resulted in `undefined symbol: XRecordQueryVersion`, which appears to be part of Xtst... which just so happens to be one of the packages installed in order to build libuiohook. Linking it solves the problem I had on Linux and allows prebuilds to work correctly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fixes #268 (says closed, but the issue actually persists even in 0.9.0)

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I manually tested one node and one electron prebuilt on a fresh clean Linux 20.04 Desktop install. With 0.9.0, an error is thrown for `undefined symbol: XRecordQueryVersion` followed by an exit with code 127, and with this PR, the lib is loaded correctly and seems to work.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
