### PR TITLE
feat: support custom binary download mirror site

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,22 @@ Found a bug? Have an idea? Feel free to post an [issue](https://github.com/wilix
 
 iohook provides prebuilt version for a bunch of OSes and platforms.
 
+## Binary installation parameters
+
+iohook supports configuration parameters to change settings related the iohook binary. Following parameters are supported:
+
+| Variable name      | .npmrc parameter   | Process argument | Value |
+| ------------------ | ------------------ | ---------------- | ----- |
+| IOHOOK_BINARY_SITE | iohook_binary_site | N/A              | URL   |
+
+These parameters can be used as environment variable:
+
+* E.g. `export IOHOOK_BINARY_SITE=http://example.com/`
+
+As local or global [.npmrc](https://docs.npmjs.com/misc/config) configuration file:
+
+* E.g. `iohook_binary_site=http://example.com/`
+
 ### Linux (including WSL)
 
 ```bash

--- a/install.js
+++ b/install.js
@@ -17,6 +17,37 @@ function onerror(err) {
 }
 
 /**
+ * Determine the URL to fetch binary file from.
+ * By default fetch from the iohook distribution
+ * site on GitHub.
+ *
+ * The default URL can be overwrite using the environment variable IOHOOK_BINARY_SITE,
+ * .npmrc variable iohook_binary_site
+ *
+ * The URL should to be the mirror of the repository
+ * laid out as follows:
+ *
+ * IOHOOK_BINARY_SITE/
+ *
+ * v0.9.3
+ * v0.9.3/iohook-v0.9.3-electron-v69-linux-x64.tar.gz
+ * ...
+ * v0.9.3/iohook-v0.9.3-electron-v87-darwin-x64.tar.gz
+ * ... etc. for all supported versions and platforms
+ *
+ * @param {string} pkgVersion
+ * @param {string} currentPlatform
+ * @returns {string}
+ */
+function getBinaryUrl(pkgVersion, currentPlatform) {
+  const site =
+    process.env.IOHOOK_BINARY_SITE ||
+    process.env.npm_config_iohook_binary_site ||
+    'https://github.com/wilix-team/iohook/releases/download';
+  return [site, 'v' + pkgVersion, currentPlatform + '.tar.gz'].join('/');
+}
+
+/**
  * Download and Install prebuild
  * @param runtime
  * @param abi
@@ -30,12 +61,7 @@ function install(runtime, abi, platform, arch, cb) {
   const currentPlatform = 'iohook-v' + pkgVersion + '-' + essential;
 
   console.log('Downloading prebuild for platform:', currentPlatform);
-  let downloadUrl =
-    'https://github.com/wilix-team/iohook/releases/download/v' +
-    pkgVersion +
-    '/' +
-    currentPlatform +
-    '.tar.gz';
+  let downloadUrl = getBinaryUrl(pkgVersion, currentPlatform);
 
   let nuggetOpts = {
     dir: os.tmpdir(),


### PR DESCRIPTION
## Description

This change empower the prebulit installation support mirror registry.

## Motivation and Context

Sometimes, _github.com_ is unstable and hard to reach.

So it might be great to download the binary from other mirror registry.

## How Has This Been Tested?

Use environment variable `IOHOOK_BINARY_SITE`.

```bash
$ IOHOOK_BINARY_SITE="some registry" npm run install
```

Or use `.npmrc` variable `iohook_binary_site`.

```bash
$ cat .npmrc
iohook_binary_site=<some registry>

$ npm run install
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly. ( I have updated `README.md`, not website document.)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
