### PR TITLE
Allow manual build from node_modules/iohook

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -7,7 +7,6 @@ docs/.vuepress/dist/
 logs/
 node_modules/
 prebuilds/
-libuiohook/
 .github/
 CMakeFiles/
 docs/
@@ -19,8 +18,6 @@ test/
 *.log
 npm-debug.log*
 stacktrace*
-/binding.gyp
-/uiohook.gyp
 .lintignore
 .eslintrc.json
 .prettierrc.json

--- a/.npmignore
+++ b/.npmignore
@@ -18,6 +18,8 @@ test/
 *.log
 npm-debug.log*
 stacktrace*
+/binding.gyp
+/uiohook.gyp
 .lintignore
 .eslintrc.json
 .prettierrc.json

--- a/docs/manual-build.md
+++ b/docs/manual-build.md
@@ -5,11 +5,11 @@ This is not required for regular users. You should follow this page only if you 
 :::
 
 ::: tip WARNING
-When you run `npm run build`, it will try to download a prebuilt for your platform/target, and sometime fail if you are building for a recent target. You can safely ignore this step and the associated warning.
+When you run `npm run build`, it will try to download a prebuild for your platform/target, and sometimes fail if you are building for a recent target with no prebuild yet available. You can safely ignore this step and the associated warning.
 :::
 
-You can build own modules directly in your node_modules under the project. Go to ~/my_project/node_modules/iohook path via terminal.
-Or you can just clone iohook repository and working on it, then copy binnary files to project's node_modules or change download path in iohook and make you own version of module.
+You can build directly in your project's node_modules. Go to the ~/my_project/node_modules/iohook path via terminal. 
+Or you can just clone the iohook repository and work there, then copy the binary files to your project's node_modules/iohook/builds/ or change the download path in iohook and make your own version of the module.
 
 Before start, you need install required dependencies for build:
 
@@ -29,7 +29,7 @@ Before start, you need install required dependencies for build:
 
 ## Windows
 
-- Install: `msys2` with `autotools`, `pkg-config`, `libtool`, `gcc`, `clang`, `glib`, `C++ Build Tools`
+- The build tools that are included with the Node.js for Windows installer are required, or manually install `windows-build-tools`
 - `npm install`
 - `npm run build`
 

--- a/install.js
+++ b/install.js
@@ -75,6 +75,7 @@ function install(runtime, abi, platform, arch, cb) {
         );
         console.error('Try to build for your platform manually:');
         console.error('# cd node_modules/iohook;');
+        console.error('# npm install');
         console.error('# npm run build');
         console.error('');
       }


### PR DESCRIPTION
The .npmignore file was causing files needed for manual build to be excluded from the project's folder when npm-installed. It's only about 500kb of files total and I noticed this was causing a lot of confusion from users trying to manually build following the (incorrect) existing instructions, so I propose here adding those back to the npm payload, that way users will be able to more easily do
```
npm install iohook
cd node_modules/iohook
npm install
npm run build
```

Also updated the manual build docs which were a little incorrect and confusing, and clarified the error messages logged by install.js.

Alternatively if you don't think this .npmignore change is a good idea then at least we should update manual-build.md and install.js to clarify that you can't build from the limited version of the repo that installs to node_modules, rather the only way to build is to clone the full repo separately.

Probably in the future libUIOHook should be added as a proper submodule but I know the version here is slightly forked from the official libUIOHook.