### PR TITLE
fix: 'non-context-aware' error for Electron

### DIFF
--- a/src/iohook.cc
+++ b/src/iohook.cc
@@ -564,4 +564,10 @@ NAN_MODULE_INIT(Init) {
   Nan::GetFunction(Nan::New<FunctionTemplate>(GrabMouseClick)).ToLocalChecked());
 }
 
-NODE_MODULE(nodeHook, Init)
+#if NODE_MAJOR_VERSION >= 10
+#define IOHOOK_DEFINE_MODULE NAN_MODULE_WORKER_ENABLED
+#else
+#define IOHOOK_DEFINE_MODULE NODE_MODULE
+#endif
+
+IOHOOK_DEFINE_MODULE(nodeHook, Init)


### PR DESCRIPTION
<!--- Provide a description of your changes in the Title -->
fix: 'non-context-aware' error for Electron

## Description
The latest releases of Electron prevent "non-context-aware" native modules. By Replacing NODE_MODULE with NAN_MODULE_WORKER_ENABLED this fixes the errors for Electron.

